### PR TITLE
feat: display annotation cards

### DIFF
--- a/src/renderer/assets/css/main.css
+++ b/src/renderer/assets/css/main.css
@@ -1692,7 +1692,6 @@ input:-webkit-autofill:focus {
 .annotate-remark-container {
     /* 多行截断 */
     display: -webkit-box;
-    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1709,6 +1708,17 @@ input:-webkit-autofill:focus {
     /* 允许单词内断行 */
     word-wrap: break-word;
     /* 紧急情况下允许单词断开 */
+}
+
+/* 内容默认两行 */
+.annotate-name-container,
+.annotate-content-container {
+    -webkit-line-clamp: 2;
+}
+
+/* 备注默认一行 */
+.annotate-remark-container {
+    -webkit-line-clamp: 1;
 }
 
 /* 溢出时显示展开按钮 */
@@ -1738,6 +1748,27 @@ input:-webkit-autofill:focus {
 .annotate-content-container.expanded::after,
 .annotate-remark-container.expanded::after {
     display: none;
+}
+
+/* 批注卡片样式 */
+.anno-card {
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    box-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
+    padding: 12px 16px;
+    margin-bottom: 8px;
+    cursor: pointer;
+}
+
+.anno-card-header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.anno-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 }
 
 

--- a/src/renderer/mainWindow/mainWindow.html
+++ b/src/renderer/mainWindow/mainWindow.html
@@ -895,7 +895,20 @@
                 </div>
             </div>
         </div>
- 
+
+        <template id="annoCardTemplate">
+            <li class="anno-card">
+                <div class="anno-card-header">
+                    <span class="anno-author">陈平安</span>
+                    <span class="anno-date">2025-10-25</span>
+                </div>
+                <div class="anno-card-body">
+                    <div class="annotate-content-container">批注内容</div>
+                    <div class="annotate-remark-container">备注</div>
+                </div>
+            </li>
+        </template>
+
         <template id="annoItemTemplateTwo">
             <div class="anno-item-body">
                 <div style="width: 17px;height: 4px;background-color: #4287F2;"></div>

--- a/src/renderer/mainWindow/mainWindow.js
+++ b/src/renderer/mainWindow/mainWindow.js
@@ -1545,7 +1545,7 @@ function checkTextOverflow() {
 }
 
 async function loadAnnotateList(isSearch = false) {
-  let annotations
+  let annotations;
   if (!isSearch) {
     if (currentDocId) {
       annotations = await window.electronAPI.db.getAnnotations({
@@ -1553,73 +1553,60 @@ async function loadAnnotateList(isSearch = false) {
         annotate_type: currentType
       });
     } else {
-      annotations = annotateTemp
+      annotations = annotateTemp;
     }
-    tempListForSearch_Anno = annotations
+    tempListForSearch_Anno = annotations;
   } else {
-    annotations = tempListForSearch_Anno
+    annotations = tempListForSearch_Anno;
   }
 
   annotateList.innerHTML = '';
-  //加载模板
-  const annoItemTemplateOne = document.getElementById('annoItemTemplateOne');
-  const annoItemTemplateTwo = document.getElementById('annoItemTemplateTwo');
-  const annoItemTemplateThree = document.getElementById('annoItemTemplateThree');
+  const template = document.getElementById('annoCardTemplate');
 
   annotations.forEach(annotate => {
-    if (annotate.processing_mode == 1) {
-      const clone = annoItemTemplateOne.content.cloneNode(true)
-      const item = clone.querySelector('.anno-item-content')
-      item.dataset.anno = JSON.stringify(annotate);
-      //填充数据
-      clone.getElementById('one-anno-name-span').textContent = annotate.author
-      clone.getElementById('one-anno-date-span').textContent = annotate.annotate_at
-      clone.getElementById('one-anno-content-span').textContent = annotate.content
-      clone.getElementById('one-anno-remark-span').textContent = annotate.annotate_note
+    const clone = template.content.cloneNode(true);
+    const card = clone.querySelector('.anno-card');
+    card.dataset.anno = JSON.stringify(annotate);
 
-      annotateList.appendChild(clone);
-    } else if (annotate.processing_mode == 2) {
-      const clone = annoItemTemplateTwo.content.cloneNode(true)
-      const item = clone.querySelector('.anno-item-content')
-      item.dataset.anno = JSON.stringify(annotate);
+    const authorEl = clone.querySelector('.anno-author');
+    const dateEl = clone.querySelector('.anno-date');
+    const contentEl = clone.querySelector('.annotate-content-container');
+    const remarkEl = clone.querySelector('.annotate-remark-container');
 
-      clone.getElementById('two-anno-name-span').textContent = annotate.author
-      clone.getElementById('two-anno-date-span').textContent = annotate.annotate_at
-      annotateList.appendChild(clone);
-    } else {
-      const clone = annoItemTemplateThree.content.cloneNode(true)
-      const item = clone.querySelector('.anno-item-content')
-      item.dataset.anno = JSON.stringify(annotate);
-      clone.getElementById('three-anno-name-span').textContent = annotate.author
-      clone.getElementById('three-anno-date-span').textContent = annotate.annotate_at
-      annotateList.appendChild(clone);
-    }
+    authorEl.textContent = annotate.author;
+    dateEl.textContent = annotate.annotate_at;
+    contentEl.textContent = annotate.content || '未录入';
+    remarkEl.textContent = annotate.annotate_note || '未录入';
 
-    // 点击后永久展开
-    document.getElementById('annotate-name-container').addEventListener('click', () => {
-      const container = document.getElementById('annotate-name-container');
-      if (container.classList.contains('overflow')) {
-        container.classList.add('expanded');
-        container.classList.remove('overflow');
+    annotateList.appendChild(clone);
+
+    applyEllipsis(contentEl, 2);
+    applyEllipsis(remarkEl, 1);
+
+    contentEl.addEventListener('click', (e) => {
+      if (contentEl.classList.contains('overflow')) {
+        contentEl.classList.add('expanded');
+        contentEl.classList.remove('overflow');
       }
+      e.stopPropagation();
     });
-    // 点击后永久展开
-    document.getElementById('annotate-content-container').addEventListener('click', () => {
-      const container = document.getElementById('annotate-content-container');
-      if (container.classList.contains('overflow')) {
-        container.classList.add('expanded');
-        container.classList.remove('overflow');
+
+    remarkEl.addEventListener('click', (e) => {
+      if (remarkEl.classList.contains('overflow')) {
+        remarkEl.classList.add('expanded');
+        remarkEl.classList.remove('overflow');
       }
+      e.stopPropagation();
     });
-    // 点击后永久展开
-    document.getElementById('annotate-remark-container').addEventListener('click', () => {
-      const container = document.getElementById('annotate-remark-container');
-      if (container.classList.contains('overflow')) {
-        container.classList.add('expanded');
-        container.classList.remove('overflow');
-      }
-    });
-  })
+  });
+}
+
+function applyEllipsis(element, lines) {
+  const lineHeight = parseFloat(getComputedStyle(element).lineHeight);
+  const maxHeight = lineHeight * lines;
+  if (element.scrollHeight > maxHeight) {
+    element.classList.add('overflow');
+  }
 }
 
 document.getElementById('search-anno').addEventListener('click', async () => {
@@ -1651,10 +1638,11 @@ document.getElementById('search-anno').addEventListener('click', async () => {
 
 
 document.getElementById('annotate-list').addEventListener('click', (e) => {
-  if (e.target.closest('.type-byhand-content')) {
-    const annoJson = e.target.closest('.type-byhand-content').dataset.anno
-    const anno = JSON.parse(annoJson)
-    showAnnotateEdit(anno)
+  const card = e.target.closest('.anno-card');
+  if (card && !e.target.classList.contains('annotate-content-container') && !e.target.classList.contains('annotate-remark-container')) {
+    const annoJson = card.dataset.anno;
+    const anno = JSON.parse(annoJson);
+    showAnnotateEdit(anno);
   }
 })
 


### PR DESCRIPTION
## Summary
- render annotations as expandable cards with author and time
- support editing and deletion via card click
## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b5548c041c832cb5504e1c3537cc72