### PR TITLE
feat: add flow status to important document list

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -988,7 +988,12 @@ ipcMain.handle('database', async (_, { action, data }) => {
       }
 
       case 'updateFlowRecord': {
-        dbInstance.statements.updateFlowRecord.run(data);
+        const params = {
+          id: data.id,
+          distributed_at: data.distributed_at ?? null,
+          back_at: data.back_at ?? null,
+        };
+        dbInstance.statements.updateFlowRecord.run(params);
         return;
       }
 

--- a/src/renderer/components/resizelist/resizelist.js
+++ b/src/renderer/components/resizelist/resizelist.js
@@ -487,7 +487,15 @@ if (!customElements.get('resizable-table')) {
                 row.dataset.index = rowIndex;
                 this.visibleKeys.forEach((key, index) => {
                     const cell = document.createElement('td');
-                    cell.textContent = rowData[index];
+                    const value = rowData[index];
+                    cell.textContent = value;
+                    if (key === 'status') {
+                        if (value === '待分发') {
+                            cell.style.color = 'red';
+                        } else if (value === '流转中') {
+                            cell.style.color = '#faad14';
+                        }
+                    }
                     row.appendChild(cell);
                 });
                 // 添加行点击事件


### PR DESCRIPTION
## Summary
- show file circulation status in important document table
- recolor status column and refresh after flow updates

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")


------
https://chatgpt.com/codex/tasks/task_e_68b64ce2f758832c81f558614deea63d