### PR TITLE
feat: add QR code generation to document menus

### DIFF
--- a/src/renderer/mainWindow/mainWindow.html
+++ b/src/renderer/mainWindow/mainWindow.html
@@ -265,6 +265,7 @@
                 <ul id="normal-context-menu" class="doc-context-menu">
                     <li id="normal-to-important">转为重要文件</li>
                     <li id="normal-edit-doc">修改文件信息</li>
+                    <li id="normal-generate-qrcode">生成二维码</li>
                 </ul>
 
             </div>
@@ -344,6 +345,7 @@
             <ul id="important-context-menu" class="doc-context-menu">
                 <li id="important-edit-doc">修改文件信息</li>
                 <li id="important-show-flow">查看文件流转</li>
+                <li id="important-generate-qrcode">生成二维码</li>
             </ul>
 
             <ul id="flow-context-menu" class="doc-context-menu">

--- a/src/renderer/mainWindow/mainWindow.js
+++ b/src/renderer/mainWindow/mainWindow.js
@@ -850,6 +850,7 @@ async function initResizableTable() {
     const norMenu = document.getElementById('normal-context-menu');
     const convertItem = document.getElementById('normal-to-important');
     const editItem = document.getElementById('normal-edit-doc');
+    const generateItem = document.getElementById('normal-generate-qrcode');
     let contextDocId = null;
     let contextDoc = null;
 
@@ -885,11 +886,19 @@ async function initResizableTable() {
       }
     });
 
+    generateItem.addEventListener('click', async () => {
+      norMenu.style.display = 'none';
+      if (contextDoc) {
+        await printDoc(contextDoc);
+      }
+    });
+
     // 为重要文档表添加行点击监听
     const impTable = document.getElementById('impTable');
     const impMenu = document.getElementById('important-context-menu');
     const impEditItem = document.getElementById('important-edit-doc');
     const impFlowItem = document.getElementById('important-show-flow');
+    const impGenerateItem = document.getElementById('important-generate-qrcode');
     let contextDocImp = null;
 
     impTable.addEventListener('row-click', (event) => {
@@ -919,6 +928,13 @@ async function initResizableTable() {
       impMenu.style.display = 'none';
       if (contextDocImp) {
         toggleFlowSidebar('view-doc-imp-left', 'view-doc-imp-right', contextDocImp);
+      }
+    });
+
+    impGenerateItem.addEventListener('click', async () => {
+      impMenu.style.display = 'none';
+      if (contextDocImp) {
+        await printDoc(contextDocImp);
       }
     });
 


### PR DESCRIPTION
## Summary
- add generate QR code option to normal and important document context menus
- invoke existing PDF417 generator to export document details as Word file

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b65e105ca8832c86b06929b5581486