### PR TITLE
feat: improve document table usability

### DIFF
--- a/src/renderer/assets/css/main.css
+++ b/src/renderer/assets/css/main.css
@@ -636,6 +636,21 @@ input:-webkit-autofill:focus {
     overflow: auto;
 }
 
+.sidebar-resizer {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 6px;
+    height: 100%;
+    cursor: col-resize;
+    background-color: transparent;
+    z-index: 10;
+}
+
+.sidebar-resizer:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
 /* 强制覆盖内联样式 */
 .view-doc-right.force-hidden {
     display: none !important;

--- a/src/renderer/components/resizelist/resizelist.js
+++ b/src/renderer/components/resizelist/resizelist.js
@@ -695,6 +695,9 @@ if (!customElements.get('resizable-table')) {
                 const key = header.getAttribute('data-key');
                 const resizer = header.querySelector('.resizer');
 
+                // Skip non-resizable columns like the fixed sequence column
+                if (!resizer) return;
+
                 resizer.addEventListener('mousedown', (e) => {
                     this.isResizing = true;
                     this.currentHeader = header;

--- a/src/renderer/components/resizelist/resizelist.js
+++ b/src/renderer/components/resizelist/resizelist.js
@@ -208,8 +208,7 @@ if (!customElements.get('resizable-table')) {
                     scrollbar-gutter: stable;
                     scroll-behavior: smooth; /* 平滑滚动 */
                 }
-                
-                                    
+
                 table {
                     border-spacing: 0;
                     table-layout: fixed;
@@ -217,58 +216,61 @@ if (!customElements.get('resizable-table')) {
                 }
 
                 th {
-                    background: rgba(246, 246, 251, 1);;
+                    background: #fafafa;
                     position: relative;
                     cursor: pointer;
-                    font-weight: 400;
+                    font-weight: 500;
                     color: rgba(29, 33, 41, 1);
                     font-size: 14px;
                     user-select: none;
                     transition: background 0.3s;
                     box-sizing: border-box;
                     text-align: left;
-                    padding: 12px 16px;
-                    border: 0.5px solid rgba(0, 0, 0, 0.2);
+                    padding: 10px 12px;
+                    border-bottom: 1px solid #e0e0e0;
                     min-width: 80px;
                     max-width: 800px;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
                 }
-                
+
                 th:hover {
-                    background-color: #f5fbff;
+                    background-color: #f5f5f5;
                 }
 
-                
                 #table-headers-table,
                 #table-body-table {
                     border-collapse: collapse;
                     table-layout: fixed; /* 保持固定布局 */
                 }
-            
+
                 #table-body-table tr {
                     transition: background-color 0.2s;
-                    border: 0.5px solid rgba(0, 0, 0, 0.2);
+                    border-bottom: 1px solid #f0f0f0;
                 }
-                
+
                 #table-body-table tr:hover {
-                    background-color: #f5fbff;
+                    background-color: #f5faff;
+                }
+
+                #table-body-table tr.selected {
+                    background-color: #e6f7ff;
                 }
 
                 #table-body-table td {
                     box-sizing: border-box;
-                    padding: 1px 1px 1px 16px;
+                    padding: 6px 8px;
                     height: 47px;
                     min-width: 60px;
                     max-width: 800px;
                     overflow: hidden;
                     word-wrap: break-word;
                     white-space: normal;
-                    border: none !important;
+                    border: none;
                 }
-                
-                #table-headers-table{
+
+                #table-headers-table {
                     border-collapse: collapse;
                 }
 
@@ -277,13 +279,42 @@ if (!customElements.get('resizable-table')) {
                     top: 0;
                     z-index: 100;
                 }
-                
-                
+
                 .sort-icon {
                     display: inline-block;
-                    margin-left: 8px;
-                    font-size: 14px;
-                    transition: transform 0.2s;
+                    width: 8px;
+                    height: 12px;
+                    margin-left: 6px;
+                    position: relative;
+                }
+
+                .sort-icon::before,
+                .sort-icon::after {
+                    content: '';
+                    position: absolute;
+                    left: 0;
+                    width: 0;
+                    height: 0;
+                    border-left: 4px solid transparent;
+                    border-right: 4px solid transparent;
+                }
+
+                .sort-icon::before {
+                    top: 0;
+                    border-bottom: 6px solid #ccc;
+                }
+
+                .sort-icon::after {
+                    bottom: 0;
+                    border-top: 6px solid #ccc;
+                }
+
+                th.asc .sort-icon::before {
+                    border-bottom-color: #1890ff;
+                }
+
+                th.desc .sort-icon::after {
+                    border-top-color: #1890ff;
                 }
                 
                 .resizer {
@@ -439,7 +470,6 @@ if (!customElements.get('resizable-table')) {
 
                 const sortIcon = document.createElement('span');
                 sortIcon.classList.add('sort-icon');
-                sortIcon.textContent = '↕';
                 th.appendChild(sortIcon);
 
                 const resizer = document.createElement('div');
@@ -504,6 +534,7 @@ if (!customElements.get('resizable-table')) {
                     if (e.target.closest('.action-btn')) return;
 
                     const originalData = this.originalData[rowIndex];
+                    this.highlightRow(rowIndex);
                     this.dispatchEvent(new CustomEvent('row-click', {
                         detail: {
                             data: originalData,
@@ -520,6 +551,20 @@ if (!customElements.get('resizable-table')) {
             this.bodyTable.style.minWidth = '100%';
         }
 
+        highlightRow(index) {
+            const rows = this.shadowRoot.querySelectorAll('#table-body tr');
+            rows.forEach((r, i) => {
+                r.classList.toggle('selected', i === index);
+            });
+            this.selectedIndex = index;
+        }
+
+        clearSelection() {
+            const rows = this.shadowRoot.querySelectorAll('#table-body tr.selected');
+            rows.forEach(r => r.classList.remove('selected'));
+            this.selectedIndex = null;
+        }
+
         // 显示右键菜单
         showContextMenu(e) {
             if (!this.contextMenu) return;
@@ -528,7 +573,7 @@ if (!customElements.get('resizable-table')) {
             menuList.innerHTML = '';
 
             this.allKeys.forEach(key => {
-                if (key === 'uuid' || key === 'created_at' || key === 'key_words' || key === 'review_leader') {
+                if (key === 'uuid' || key === 'created_at' || key === 'docType' || key === 'doc_type' || key === 'review_leader') {
                     return
                 }
                 const isVisible = this.visibleKeys.includes(key);
@@ -628,7 +673,7 @@ if (!customElements.get('resizable-table')) {
                 resizer.addEventListener('mousedown', (e) => {
                     this.isResizing = true;
                     this.currentHeader = header;
-                    this.startX = e.clientX;
+                    this.startX = e.clientX + this.headerContainer.scrollLeft;
                     this.startWidth = header.getBoundingClientRect().width;
                     resizer.classList.add('active');
 
@@ -650,7 +695,7 @@ if (!customElements.get('resizable-table')) {
 
             const MIN_WIDTH = 120;
             const MAX_WIDTH = 800;
-            let newWidth = this.startWidth + (e.clientX - this.startX);
+            let newWidth = this.startWidth + (e.clientX + this.headerContainer.scrollLeft - this.startX);
             newWidth = Math.max(MIN_WIDTH, Math.min(newWidth, MAX_WIDTH));
 
             // 更新当前列的宽度
@@ -738,11 +783,9 @@ if (!customElements.get('resizable-table')) {
                     this.sortColumn = index;
 
                     headers.forEach((h, i) => {
-                        const ic = h.querySelector('.sort-icon');
+                        h.classList.remove('asc', 'desc');
                         if (i === index) {
-                            ic.textContent = this.sortDirection === 'asc' ? '↑' : '↓';
-                        } else if (!isMultiSort) {
-                            ic.textContent = '↕';
+                            h.classList.add(this.sortDirection);
                         }
                     });
 

--- a/src/renderer/mainWindow/mainWindow.html
+++ b/src/renderer/mainWindow/mainWindow.html
@@ -235,6 +235,7 @@
                                 </div>
                             </div>
                             <div id="view-doc-nor-right" class="view-doc-right">
+                                <div class="sidebar-resizer"></div>
                                 <div class="view-doc-right-body">
                                     <div class="view-doc-right-top">
                                         <span class="annotate-list-title">批注</span>
@@ -292,6 +293,7 @@
                                 </div>
                             </div>
                             <div id="view-doc-imp-right" class="view-doc-right">
+                                <div class="sidebar-resizer"></div>
                                 <div id="imp-anno-panel" class="view-doc-right-body">
                                     <div class="view-doc-right-top">
                                         <span class="annotate-list-title">批注</span>

--- a/src/renderer/mainWindow/mainWindow.js
+++ b/src/renderer/mainWindow/mainWindow.js
@@ -610,6 +610,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     * 刷新列表
     */
   initResizableTable();
+  initSidebarResizer('view-doc-nor-left', 'view-doc-nor-right');
+  initSidebarResizer('view-doc-imp-left', 'view-doc-imp-right');
 
 
 })
@@ -626,6 +628,8 @@ function hideAnnoSidebar(leftContainer, rightContainer) {
     rightContainer.classList.remove('force-hidden');
   }, 400);
   leftContainer.classList.remove('split-view');
+  leftContainer.style.width = '';
+  rightContainer.style.width = '';
   rightContainer.dataset.mode = '';
 
   const table = leftContainer.querySelector('resizable-table');
@@ -650,6 +654,9 @@ function toggleAnnoSidebar(leftId, rightId, rowData) {
   rightContainer.style.display = 'flex';
   void rightContainer.offsetHeight;
   rightContainer.classList.add('active');
+  const defaultWidth = parseInt(rightContainer.style.width) || 360;
+  rightContainer.style.width = defaultWidth + 'px';
+  leftContainer.style.width = `calc(100% - ${defaultWidth}px)`;
   if (rightId === 'view-doc-imp-right') {
     rightContainer.dataset.mode = 'anno';
     const annoPanel = document.getElementById('imp-anno-panel');
@@ -686,6 +693,9 @@ function toggleFlowSidebar(leftId, rightId, rowData) {
   rightContainer.style.display = 'flex';
   void rightContainer.offsetHeight;
   rightContainer.classList.add('active');
+  const defaultWidth = parseInt(rightContainer.style.width) || 360;
+  rightContainer.style.width = defaultWidth + 'px';
+  leftContainer.style.width = `calc(100% - ${defaultWidth}px)`;
   rightContainer.dataset.mode = 'flow';
   const annoPanel = document.getElementById('imp-anno-panel');
   const flowPanel = document.getElementById('imp-flow-panel');
@@ -701,6 +711,40 @@ function toggleFlowSidebar(leftId, rightId, rowData) {
     document.getElementById('flow-back').value = '';
   }
   loadFlowList();
+}
+
+function initSidebarResizer(leftId, rightId) {
+  const left = document.getElementById(leftId);
+  const right = document.getElementById(rightId);
+  const resizer = right?.querySelector('.sidebar-resizer');
+  if (!left || !right || !resizer) return;
+
+  let startX, startLeft, startRight;
+
+  resizer.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    startX = e.clientX;
+    startLeft = left.getBoundingClientRect().width;
+    startRight = right.getBoundingClientRect().width;
+    document.addEventListener('mousemove', onDrag);
+    document.addEventListener('mouseup', stopDrag);
+  });
+
+  const onDrag = (e) => {
+    const dx = startX - e.clientX;
+    const containerWidth = left.parentElement.getBoundingClientRect().width;
+    let newRight = startRight + dx;
+    const min = 200;
+    newRight = Math.min(Math.max(newRight, min), containerWidth - min);
+    const newLeft = containerWidth - newRight;
+    right.style.width = `${newRight}px`;
+    left.style.width = `${newLeft}px`;
+  };
+
+  const stopDrag = () => {
+    document.removeEventListener('mousemove', onDrag);
+    document.removeEventListener('mouseup', stopDrag);
+  };
 }
 
 async function loadFlowList() {
@@ -1083,7 +1127,7 @@ async function refreshDocList(type = 1, searchResult = null, _searchKey = null) 
     table.setHeaderMap(headerMap)
 
     const columnWidths = {
-      id: 70,
+      id: 60,
       title: 280,
       sender_unit: 180,
       sender_number: 140,

--- a/src/renderer/mainWindow/mainWindow.js
+++ b/src/renderer/mainWindow/mainWindow.js
@@ -1083,7 +1083,7 @@ async function refreshDocList(type = 1, searchResult = null, _searchKey = null) 
     table.setHeaderMap(headerMap)
 
     const columnWidths = {
-      id: 60,
+      id: 70,
       title: 280,
       sender_unit: 180,
       sender_number: 140,

--- a/src/renderer/mainWindow/mainWindow.js
+++ b/src/renderer/mainWindow/mainWindow.js
@@ -627,6 +627,9 @@ function hideAnnoSidebar(leftContainer, rightContainer) {
   }, 400);
   leftContainer.classList.remove('split-view');
   rightContainer.dataset.mode = '';
+
+  const table = leftContainer.querySelector('resizable-table');
+  table?.clearSelection();
 }
 
 function toggleAnnoSidebar(leftId, rightId, rowData) {
@@ -866,6 +869,7 @@ async function initResizableTable() {
       e.preventDefault();
       contextDoc = norTable.originalData[row.dataset.index];
       contextDocId = contextDoc.uuid;
+      norTable.highlightRow(Number(row.dataset.index));
       norMenu.style.display = 'block';
       norMenu.style.left = `${e.clientX}px`;
       norMenu.style.top = `${e.clientY}px`;
@@ -911,6 +915,7 @@ async function initResizableTable() {
       if (!row) return;
       e.preventDefault();
       contextDocImp = impTable.originalData[row.dataset.index];
+      impTable.highlightRow(Number(row.dataset.index));
       impMenu.style.display = 'block';
       impMenu.style.left = `${e.clientX}px`;
       impMenu.style.top = `${e.clientY}px`;
@@ -1067,7 +1072,8 @@ async function refreshDocList(type = 1, searchResult = null, _searchKey = null) 
       crgency_level: '紧急程度',
       secrecy_period: '保密期限',
       review_leader: '呈阅领导',
-      remarks: '标记'
+      key_words: '关键词',
+      remarks: '备注'
     }
 
     if (type === 2) {
@@ -1076,6 +1082,24 @@ async function refreshDocList(type = 1, searchResult = null, _searchKey = null) 
 
     table.setHeaderMap(headerMap)
 
+    const columnWidths = {
+      id: 60,
+      title: 280,
+      sender_unit: 180,
+      sender_number: 140,
+      drafting_unit: 180,
+      input_user: 100,
+      sender_date: 160,
+      secrecy_level: 120,
+      crgency_level: 120,
+      secrecy_period: 120,
+      review_leader: 150,
+      key_words: 200,
+      remarks: 180,
+      status: 120
+    }
+
+    table.columnWidths = columnWidths
     table.setData(docs)
 
     if (type === 2) {


### PR DESCRIPTION
## Summary
- polish table styling and sorting icons for modern look
- refine column menu and widths to include keywords and drop docType
- sync column drag and highlight selected rows during sidebar view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/renderer/components/resizelist/resizelist.js src/renderer/mainWindow/mainWindow.js` *(errors: @typescript-eslint/no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b661c6752c832cba2921cf6782d42f