### PR TITLE
feat: add audit log retention setting

### DIFF
--- a/src/database/initDB.js
+++ b/src/database/initDB.js
@@ -1,6 +1,6 @@
 const Database = require('better-sqlite3');
 // const { create } = require('core-js/core/object');
-const { app } = require('electron');
+const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -726,6 +726,9 @@ class DB {
   logOperation(params) {
     this.statements.logOperation.run(params);
     this.deleteExpiredAuditLogs();
+    BrowserWindow.getAllWindows().forEach(win => {
+      win.webContents.send('audit-log-updated');
+    });
   }
 
   convertToImportant(normalUuid) {

--- a/src/database/initDB.js
+++ b/src/database/initDB.js
@@ -17,6 +17,7 @@ class DB {
     this.connection.pragma('foreign_keys = ON');
     this.initializeSchema();
     this.prepareStatements();
+    this.deleteExpiredAuditLogs();
   }
 
   initializeSchema() {
@@ -129,6 +130,15 @@ class DB {
         details TEXT NOT NULL,
         operation_time DATETIME DEFAULT (datetime('now', 'localtime'))
       );
+
+      -- 系统设置表
+      CREATE TABLE IF NOT EXISTS settings (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+
+      INSERT OR IGNORE INTO settings(key, value)
+      VALUES('audit_retention_years', '3');
 
       --关键词管理列表
       CREATE TABLE IF NOT EXISTS key_words (
@@ -538,6 +548,17 @@ class DB {
         )
       `),
 
+      // 审计日志保留设置
+      getAuditRetention: this.connection.prepare(
+        "SELECT value FROM settings WHERE key = 'audit_retention_years'"
+      ),
+      setAuditRetention: this.connection.prepare(
+        "INSERT INTO settings (key, value) VALUES ('audit_retention_years', @value) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+      ),
+      deleteOldAuditLogs: this.connection.prepare(
+        "DELETE FROM audit_log WHERE operation_time < datetime('now', @limit)"
+      ),
+
       getOperations: this.connection.prepare(`
        SELECT * FROM audit_log ORDER BY operation_time DESC
       `),
@@ -686,6 +707,25 @@ class DB {
       `),
 
     };
+  }
+
+  getAuditRetention() {
+    const row = this.statements.getAuditRetention.get();
+    return row ? parseInt(row.value, 10) : 3;
+  }
+
+  setAuditRetention(years) {
+    this.statements.setAuditRetention.run({ value: String(years) });
+  }
+
+  deleteExpiredAuditLogs() {
+    const years = this.getAuditRetention();
+    this.statements.deleteOldAuditLogs.run({ limit: `-${years} years` });
+  }
+
+  logOperation(params) {
+    this.statements.logOperation.run(params);
+    this.deleteExpiredAuditLogs();
   }
 
   convertToImportant(normalUuid) {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -219,7 +219,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
 
         }
         if (lastRowId) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               operation_type: aes256.encrypt('创建'),
               table_name: aes256.encrypt('documents'),
@@ -340,7 +340,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
           });
 
           if (result.changes > 0) {
-            dbInstance.statements.logOperation.run(
+            dbInstance.logOperation(
               {
                 operation_type: aes256.encrypt('更新'),
                 table_name: aes256.encrypt('documents'),
@@ -361,7 +361,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
           console.log('删除影响行数:', result.changes);
 
           if (result.changes > 0) {
-            dbInstance.statements.logOperation.run(
+            dbInstance.logOperation(
               {
                 operation_type: aes256.encrypt('删除'),
                 table_name: aes256.encrypt('documents'),
@@ -378,7 +378,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
       case 'convertToImportant': {
         const uuid = dbInstance.convertToImportant(data);
         if (uuid) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               operation_type: aes256.encrypt('转重要'),
               table_name: aes256.encrypt('documents'),
@@ -409,7 +409,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
           });
 
         if (uuid) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               operation_type: aes256.encrypt('新建'),
               table_name: aes256.encrypt('annotations'),
@@ -467,7 +467,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
           }
         );
         if (id) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               operation_type: aes256.encrypt('更新'),
               table_name: aes256.encrypt('annotations'),
@@ -482,7 +482,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
       case 'deleteAnnotate': {
         const annoId = dbInstance.statements.deleteAnnotate.run({ id: data });
         if (annoId) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('annotations'),
               operation_type: aes256.encrypt('删除'),
@@ -513,7 +513,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
         const encryptedUnit = aes256.encrypt(data.unit);
         const result = dbInstance.statements.createAuthor.get({ name: encryptedName, unit: encryptedUnit });
         if (result) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('authors'),
               operator: aes256.encrypt(currentAccount.username),
@@ -531,7 +531,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
         const encryName = data.map(name => aes256.encrypt(name))
         const result = dbInstance.createAuthors(encryName);
         if (result) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('authors'),
               operator: aes256.encrypt(currentAccount.username),
@@ -552,7 +552,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
           alias: aes256.encrypt(data.alias)
         }).lastInsertRowid;
         if (aliaId) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('author_alias'),
               operator: aes256.encrypt(currentAccount.username),
@@ -627,7 +627,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
 
         return dbInstance.connection.transaction(() => {
           dbInstance.statements.deleteAuthor.run({ authorId: data });
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('authors'),
               operator: aes256.encrypt(currentAccount.username),
@@ -641,7 +641,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
       case 'deleteAlias': {
         const change = dbInstance.statements.deleteAlias.run({ aliasId: data }).changes
         if (change) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('author_alias'),
               operator: aes256.encrypt(currentAccount.username),
@@ -684,7 +684,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
         });
 
         if (id) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('author_alias'),
               operator: aes256.encrypt(currentAccount.username),
@@ -710,7 +710,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
         const encryptedName = aes256.encrypt(data.name);
         const result = dbInstance.statements.createUnit.get({ name: encryptedName });
         if (result) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('author_alias'),
               operator: aes256.encrypt(currentAccount.username),
@@ -730,7 +730,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
           unit_son_name: aes256.encrypt(data.unit_son_name)
         }).lastInsertRowid;
         if (result) {
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('author_alias'),
               operator: aes256.encrypt(currentAccount.username),
@@ -852,7 +852,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
       case 'deleteUnit':
         return dbInstance.connection.transaction(() => {
           dbInstance.statements.deleteUnit.run({ unitId: data });
-          dbInstance.statements.logOperation.run(
+          dbInstance.logOperation(
             {
               table_name: aes256.encrypt('author_alias'),
               operator: aes256.encrypt(currentAccount.username),
@@ -866,7 +866,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
 
       case 'deleteUnitSon': {
         const changes = dbInstance.statements.deleteUnitSon.run({ unitSonId: data }).changes;
-        dbInstance.statements.logOperation.run(
+        dbInstance.logOperation(
           {
             table_name: aes256.encrypt('unit'),
             operator: aes256.encrypt(currentAccount.username),
@@ -910,7 +910,7 @@ ipcMain.handle('database', async (_, { action, data }) => {
           encryUnit,
           encryUnitSons,
         );
-        dbInstance.statements.logOperation.run(
+        dbInstance.logOperation(
           {
             table_name: aes256.encrypt('unit-unitson'),
             operator: aes256.encrypt(currentAccount.username),
@@ -1098,6 +1098,15 @@ ipcMain.handle('getLevel', async () => {
 })
 ipcMain.handle('getCurrentAcconutName', async () => {
   return currentAccount.username
+})
+
+ipcMain.handle('getAuditRetention', async () => {
+  return dbInstance.getAuditRetention();
+})
+
+ipcMain.handle('setAuditRetention', async (_event, value) => {
+  dbInstance.setAuditRetention(value);
+  return true;
 })
 
 ipcMain.handle('get-cascader-data', async () => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -33,6 +33,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('window-unmaximized', callback)
   },
 
+  onAuditLogUpdated: (callback) => {
+    ipcRenderer.on('audit-log-updated', callback)
+    return () => ipcRenderer.removeListener('audit-log-updated', callback)
+  },
+
   sendLogin: (userData) => ipcRenderer.send('login-success', userData),
   getLevel: () => ipcRenderer.invoke('getLevel'),
   getCurrentAcconutName: () => ipcRenderer.invoke('getCurrentAcconutName'),

--- a/src/preload.js
+++ b/src/preload.js
@@ -38,6 +38,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getCurrentAcconutName: () => ipcRenderer.invoke('getCurrentAcconutName'),
   readConfig: () => ipcRenderer.invoke('read-config'),
   getCascaderData: () => ipcRenderer.invoke('get-cascader-data'),
+  getAuditRetention: () => ipcRenderer.invoke('getAuditRetention'),
+  setAuditRetention: (value) => ipcRenderer.invoke('setAuditRetention', value),
 
   showSaveDialog: (options) => ipcRenderer.invoke('show-save-dialog', options),
   generateAndExport: (data) => ipcRenderer.invoke('save-document', data),

--- a/src/renderer/mainWindow/mainWindow.html
+++ b/src/renderer/mainWindow/mainWindow.html
@@ -1026,6 +1026,13 @@
                                 <span>分钟</span>
                             </div>
                         </div>
+                        <div class="settings-item">
+                            <span>审计保留</span>
+                            <div class="time-input">
+                                <input type="number" id="audit-retention-years" min="1">
+                                <span>年</span>
+                            </div>
+                        </div>
                         <div class="settings-item password-item">
                             <input type="password" id="new-password" placeholder="新密码">
                         </div>

--- a/src/renderer/mainWindow/mainWindow.js
+++ b/src/renderer/mainWindow/mainWindow.js
@@ -3192,6 +3192,10 @@ async function loadAudit() {
   }
 }
 
+window.electronAPI.onAuditLogUpdated(() => {
+  loadAudit()
+})
+
 //关键词管理
 async function initKeywordTable() {
   const table = document.getElementById('keyword-list');

--- a/src/renderer/mainWindow/mainWindow.js
+++ b/src/renderer/mainWindow/mainWindow.js
@@ -3341,6 +3341,7 @@ async function loadSetting() {
   const autoEnable = document.getElementById('auto-logout-enable')
   const autoMinutes = document.getElementById('auto-logout-minutes')
   const autoTimeRow = document.getElementById('auto-logout-time-row')
+  const auditRetention = document.getElementById('audit-retention-years')
   const newPwd = document.getElementById('new-password')
   const confirmPwd = document.getElementById('confirm-password')
 
@@ -3351,6 +3352,8 @@ async function loadSetting() {
   autoEnable.checked = autoLogoutEnabled
   autoMinutes.value = autoLogoutTime
   autoTimeRow.style.display = autoLogoutEnabled ? 'flex' : 'none'
+  const retentionYears = await window.electronAPI.getAuditRetention()
+  auditRetention.value = retentionYears
 
   const closeModal = () => {
     settingsModal.style.display = 'none'
@@ -3379,6 +3382,11 @@ async function loadSetting() {
     autoLogoutTime = parseInt(autoMinutes.value, 10) || 15
     localStorage.setItem(key, JSON.stringify({ enabled: autoLogoutEnabled, minutes: autoLogoutTime }))
     resetIdleTimer()
+  })
+
+  auditRetention.addEventListener('change', () => {
+    const years = parseInt(auditRetention.value, 10) || 3
+    window.electronAPI.setAuditRetention(years)
   })
 
   changePwdBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add settings table to persist audit log retention period
- expose IPC and UI to configure audit retention in settings modal
- auto-remove audit logs older than configured retention (default 3 years)

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b789858da8832cb4db6ba1a406777a