### PR TITLE
feat: refine window chrome

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -20,6 +20,8 @@ function createWindow() {
     height: 768,
     titleBarStyle: 'hidden',
     frame: false,
+    resizable: false,
+    maximizable: false,
     webPreferences: {
       preload: path.join(__dirname, '..', 'preload.js'),
       contextIsolation: true,
@@ -79,6 +81,8 @@ function createMainWindow() {
     height: 768,
     titleBarStyle: 'hidden',
     frame: false,
+    resizable: false,
+    maximizable: false,
     webPreferences: {
       preload: path.join(__dirname, '../preload.js'),
       contextIsolation: true,
@@ -118,17 +122,6 @@ ipcMain.on('minimize-window', () => {
   // 主窗口可能尚未创建，添加严格判断
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.minimize()
-  }
-})
-
-ipcMain.on('maximize-window', () => {
-  // 优先处理当前活动窗口
-  const targetWindow = mainWindow || loginWindow
-
-  if (targetWindow && !targetWindow.isDestroyed()) {
-    targetWindow.isMaximized()
-      ? targetWindow.unmaximize()
-      : targetWindow.maximize()
   }
 })
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -13,24 +13,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     console.log('[Preload] 发送最小化请求')
     ipcRenderer.send('minimize-window')
   },
-  maximize: () => {
-    console.log('[Preload] 发送最大化请求')
-    ipcRenderer.send('maximize-window')
-  },
   close: () => {
     console.log('[Preload] 发送关闭请求')
     ipcRenderer.send('close-window')
   },
   logout: () => {
     ipcRenderer.send('logout')
-  },
-  onMaximized: (callback) => {
-    ipcRenderer.on('window-maximized', callback)
-    return () => ipcRenderer.removeListener('window-maximized', callback)
-  },
-  onUnmaximized: (callback) => {
-    ipcRenderer.on('window-unmaximized', callback)
-    return () => ipcRenderer.removeListener('window-unmaximized', callback)
   },
 
   onAuditLogUpdated: (callback) => {

--- a/src/renderer/assets/css/index.css
+++ b/src/renderer/assets/css/index.css
@@ -13,9 +13,9 @@ body {
 }
 
 body {
-  border: 1px solid #d0d0d0;
+  background-color: #fff;
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 0 1px #d0d0d0, 0 4px 16px rgba(0, 0, 0, 0.2);
   overflow: hidden;
 }
 
@@ -66,11 +66,23 @@ body {
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  transition: background 0.2s;
+  position: relative;
+  overflow: visible;
 }
 
-.control-btn:hover {
-  background: rgba(0, 0, 0, 0.1);
+.control-btn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  transition: background 0.2s, transform 0.2s;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.control-btn:hover::before {
+  background: rgba(0, 0, 0, 0.05);
+  transform: scale(0.8);
 }
 
 .control-icon {

--- a/src/renderer/assets/css/index.css
+++ b/src/renderer/assets/css/index.css
@@ -13,9 +13,9 @@ body {
 }
 
 body {
-  border: 2px solid #3daee9;
+  border: 1px solid #d0d0d0;
   border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
   overflow: hidden;
 }
 
@@ -48,6 +48,7 @@ body {
 }
 
 /* 窗口控制按钮 */
+
 #window-controls {
   display: flex;
   height: 100%;
@@ -56,31 +57,25 @@ body {
 }
 
 .control-btn {
-  width: 40px;
-  height: 100%;
+  width: 30px;
+  height: 30px;
   border: none;
-  color: white;
+  color: #555;
   background-color: transparent;
   display: flex;
   align-items: center;
   justify-content: center;
+  border-radius: 50%;
   transition: background 0.2s;
 }
 
 .control-btn:hover {
-  background: #4a4a4a;
-  border-radius: 8px;
-}
-
-#close:hover {
-  background: #e94a57 !important;
-  border-radius: 8px;
-  color: white;
+  background: rgba(0, 0, 0, 0.1);
 }
 
 .control-icon {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 }
 
 .main-container {

--- a/src/renderer/assets/css/index.css
+++ b/src/renderer/assets/css/index.css
@@ -12,6 +12,13 @@ body {
   margin: 0;
 }
 
+body {
+  border: 2px solid #3daee9;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
 /* 标题栏样式 */
 #titlebar {
   height: 30px;
@@ -54,6 +61,9 @@ body {
   border: none;
   color: white;
   background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: background 0.2s;
 }
 
@@ -65,6 +75,12 @@ body {
 #close:hover {
   background: #e94a57 !important;
   border-radius: 8px;
+  color: white;
+}
+
+.control-icon {
+  width: 16px;
+  height: 16px;
 }
 
 .main-container {

--- a/src/renderer/assets/css/index.css
+++ b/src/renderer/assets/css/index.css
@@ -15,7 +15,8 @@ body {
 body {
   background-color: #fff;
   border-radius: 8px;
-  box-shadow: 0 0 0 1px #d0d0d0, 0 4px 16px rgba(0, 0, 0, 0.2);
+  border: 1px solid #d0d0d0;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
   overflow: hidden;
 }
 
@@ -77,7 +78,7 @@ body {
   border-radius: 50%;
   transition: background 0.2s, transform 0.2s;
   pointer-events: none;
-  z-index: -1;
+  z-index: 0;
 }
 
 .control-btn:hover::before {
@@ -88,6 +89,8 @@ body {
 .control-icon {
   width: 14px;
   height: 14px;
+  position: relative;
+  z-index: 1;
 }
 
 .main-container {

--- a/src/renderer/assets/css/loginnew.css
+++ b/src/renderer/assets/css/loginnew.css
@@ -3,6 +3,11 @@ body {
     height: 100vh;
     margin: 0;
     padding: 0;
+    box-sizing: border-box;
+    border: 2px solid #3daee9;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    overflow: hidden;
 }
 
 /* 标题栏样式 */
@@ -55,6 +60,9 @@ body {
     border: none;
     color: white;
     background-color: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     transition: background 0.2s;
 }
 
@@ -66,6 +74,12 @@ body {
 #close:hover {
     background: #e94a57 !important;
     border-radius: 8px;
+    color: white;
+}
+
+.control-icon {
+    width: 16px;
+    height: 16px;
 }
 
 .login-container {

--- a/src/renderer/assets/css/loginnew.css
+++ b/src/renderer/assets/css/loginnew.css
@@ -4,9 +4,9 @@ body {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    border: 1px solid #d0d0d0;
+    background-color: #fff;
     border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 0 1px #d0d0d0, 0 4px 16px rgba(0, 0, 0, 0.2);
     overflow: hidden;
 }
 
@@ -64,11 +64,23 @@ body {
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-    transition: background 0.2s;
+    position: relative;
+    overflow: visible;
 }
 
-.control-btn:hover {
-    background: rgba(0, 0, 0, 0.1);
+.control-btn::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    transition: background 0.2s, transform 0.2s;
+    pointer-events: none;
+    z-index: -1;
+}
+
+.control-btn:hover::before {
+    background: rgba(0, 0, 0, 0.05);
+    transform: scale(0.8);
 }
 
 .control-icon {

--- a/src/renderer/assets/css/loginnew.css
+++ b/src/renderer/assets/css/loginnew.css
@@ -4,9 +4,9 @@ body {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    border: 2px solid #3daee9;
+    border: 1px solid #d0d0d0;
     border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
     overflow: hidden;
 }
 
@@ -55,31 +55,25 @@ body {
 }
 
 .control-btn {
-    width: 40px;
-    height: 100%;
+    width: 30px;
+    height: 30px;
     border: none;
-    color: white;
+    color: #555;
     background-color: transparent;
     display: flex;
     align-items: center;
     justify-content: center;
+    border-radius: 50%;
     transition: background 0.2s;
 }
 
 .control-btn:hover {
-    background: #4a4a4a;
-    border-radius: 8px;
-}
-
-#close:hover {
-    background: #e94a57 !important;
-    border-radius: 8px;
-    color: white;
+    background: rgba(0, 0, 0, 0.1);
 }
 
 .control-icon {
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
 }
 
 .login-container {

--- a/src/renderer/assets/css/loginnew.css
+++ b/src/renderer/assets/css/loginnew.css
@@ -6,7 +6,8 @@ body {
     box-sizing: border-box;
     background-color: #fff;
     border-radius: 8px;
-    box-shadow: 0 0 0 1px #d0d0d0, 0 4px 16px rgba(0, 0, 0, 0.2);
+    border: 1px solid #d0d0d0;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
     overflow: hidden;
 }
 
@@ -75,7 +76,7 @@ body {
     border-radius: 50%;
     transition: background 0.2s, transform 0.2s;
     pointer-events: none;
-    z-index: -1;
+    z-index: 0;
 }
 
 .control-btn:hover::before {
@@ -86,6 +87,8 @@ body {
 .control-icon {
     width: 14px;
     height: 14px;
+    position: relative;
+    z-index: 1;
 }
 
 .login-container {

--- a/src/renderer/assets/css/main.css
+++ b/src/renderer/assets/css/main.css
@@ -4,6 +4,11 @@ body {
     height: 100vh;
     display: flex;
     flex-direction: row;
+    box-sizing: border-box;
+    border: 2px solid #3daee9;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    overflow: hidden;
 }
 
 hr {
@@ -194,7 +199,7 @@ hr {
 /* 窗口控制按钮 */
 #window-controls {
     display: flex;
-    height: 18px;
+    height: 24px;
     -webkit-app-region: no-drag;
     flex-direction: row;
     justify-content: end;
@@ -202,17 +207,31 @@ hr {
 }
 
 .control-btn {
-    width: 18px;
-    height: 18px;
+    width: 24px;
+    height: 24px;
     border: none;
     color: rgb(44, 44, 44);
     background-color: transparent;
     margin-left: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     transition: background 0.2s;
 }
 
 .control-btn:hover {
     background: #4a4a4a;
+    color: white;
+}
+
+#close:hover {
+    background: #e94a57 !important;
+    color: white;
+}
+
+.control-icon {
+    width: 16px;
+    height: 16px;
 }
 
 .setting-box {

--- a/src/renderer/assets/css/main.css
+++ b/src/renderer/assets/css/main.css
@@ -5,9 +5,9 @@ body {
     display: flex;
     flex-direction: row;
     box-sizing: border-box;
-    border: 2px solid #3daee9;
+    border: 1px solid #d0d0d0;
     border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
     overflow: hidden;
 }
 
@@ -199,7 +199,7 @@ hr {
 /* 窗口控制按钮 */
 #window-controls {
     display: flex;
-    height: 24px;
+    height: 30px;
     -webkit-app-region: no-drag;
     flex-direction: row;
     justify-content: end;
@@ -207,31 +207,26 @@ hr {
 }
 
 .control-btn {
-    width: 24px;
-    height: 24px;
+    width: 30px;
+    height: 30px;
     border: none;
-    color: rgb(44, 44, 44);
+    color: #555;
     background-color: transparent;
     margin-left: 5px;
     display: flex;
     align-items: center;
     justify-content: center;
+    border-radius: 50%;
     transition: background 0.2s;
 }
 
 .control-btn:hover {
-    background: #4a4a4a;
-    color: white;
-}
-
-#close:hover {
-    background: #e94a57 !important;
-    color: white;
+    background: rgba(0, 0, 0, 0.1);
 }
 
 .control-icon {
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
 }
 
 .setting-box {

--- a/src/renderer/assets/css/main.css
+++ b/src/renderer/assets/css/main.css
@@ -7,7 +7,8 @@ body {
     box-sizing: border-box;
     background-color: #fff;
     border-radius: 8px;
-    box-shadow: 0 0 0 1px #d0d0d0, 0 4px 16px rgba(0, 0, 0, 0.2);
+    border: 1px solid #d0d0d0;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
     overflow: hidden;
 }
 
@@ -228,7 +229,7 @@ hr {
     border-radius: 50%;
     transition: background 0.2s, transform 0.2s;
     pointer-events: none;
-    z-index: -1;
+    z-index: 0;
 }
 
 .control-btn:hover::before {
@@ -239,6 +240,8 @@ hr {
 .control-icon {
     width: 14px;
     height: 14px;
+    position: relative;
+    z-index: 1;
 }
 
 .setting-box {

--- a/src/renderer/assets/css/main.css
+++ b/src/renderer/assets/css/main.css
@@ -5,9 +5,9 @@ body {
     display: flex;
     flex-direction: row;
     box-sizing: border-box;
-    border: 1px solid #d0d0d0;
+    background-color: #fff;
     border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 0 1px #d0d0d0, 0 4px 16px rgba(0, 0, 0, 0.2);
     overflow: hidden;
 }
 
@@ -217,11 +217,23 @@ hr {
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-    transition: background 0.2s;
+    position: relative;
+    overflow: visible;
 }
 
-.control-btn:hover {
-    background: rgba(0, 0, 0, 0.1);
+.control-btn::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    transition: background 0.2s, transform 0.2s;
+    pointer-events: none;
+    z-index: -1;
+}
+
+.control-btn:hover::before {
+    background: rgba(0, 0, 0, 0.05);
+    transform: scale(0.8);
 }
 
 .control-icon {

--- a/src/renderer/loginWindow/login.html
+++ b/src/renderer/loginWindow/login.html
@@ -12,12 +12,12 @@
         <div id="window-controls">
             <button id="minimize" class="control-btn">
                 <svg class="control-icon" viewBox="0 0 10 10">
-                    <path d="M2 2h6v6" fill="none" stroke="currentColor" stroke-width="2" />
+                    <path d="M2 3l3 3 3-3" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
                 </svg>
             </button>
             <button id="close" class="control-btn">
                 <svg class="control-icon" viewBox="0 0 10 10">
-                    <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" stroke-width="2" />
+                    <path d="M3 3l4 4M7 3L3 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
                 </svg>
             </button>
         </div>

--- a/src/renderer/loginWindow/login.html
+++ b/src/renderer/loginWindow/login.html
@@ -10,9 +10,16 @@
     <div id="titlebar">
         <div id="drag-region">数据库管理系统</div>
         <div id="window-controls">
-            <button id="minimize" class="control-btn">_</button>
-            <button id="maximize" class="control-btn">□</button>
-            <button id="close" class="control-btn">x</button>
+            <button id="minimize" class="control-btn">
+                <svg class="control-icon" viewBox="0 0 10 10">
+                    <path d="M2 2h6v6" fill="none" stroke="currentColor" stroke-width="2" />
+                </svg>
+            </button>
+            <button id="close" class="control-btn">
+                <svg class="control-icon" viewBox="0 0 10 10">
+                    <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" stroke-width="2" />
+                </svg>
+            </button>
         </div>
     </div>
     <div class="login-content">

--- a/src/renderer/loginWindow/login.js
+++ b/src/renderer/loginWindow/login.js
@@ -11,7 +11,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 获取控制按钮
     const minimizeBtn = getElement('minimize')
-    const maximizeBtn = getElement('maximize')
     const closeBtn = getElement('close')
 
     // 验证API可用性
@@ -25,25 +24,6 @@ document.addEventListener('DOMContentLoaded', () => {
         minimizeBtn.addEventListener('click', () => {
             console.log('[事件] 点击最小化按钮')
             window.electronAPI.minimize()
-        })
-    }
-
-    // 最大化/还原按钮
-    if (maximizeBtn) {
-        maximizeBtn.addEventListener('click', () => {
-            console.log('[事件] 点击最大化按钮')
-            window.electronAPI.maximize()
-        })
-
-        // 状态同步
-        window.electronAPI.onMaximized(() => {
-            maximizeBtn.textContent = '❐'
-            console.log('[状态] 窗口最大化')
-        })
-
-        window.electronAPI.onUnmaximized(() => {
-            maximizeBtn.textContent = '□'
-            console.log('[状态] 窗口还原')
         })
     }
 

--- a/src/renderer/loginWindow/loginnew.html
+++ b/src/renderer/loginWindow/loginnew.html
@@ -8,12 +8,12 @@
         <div id="window-controls">
             <button id="minimize" class="control-btn">
                 <svg class="control-icon" viewBox="0 0 10 10">
-                    <path d="M2 2h6v6" fill="none" stroke="currentColor" stroke-width="2" />
+                    <path d="M2 3l3 3 3-3" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
                 </svg>
             </button>
             <button id="close" class="control-btn">
                 <svg class="control-icon" viewBox="0 0 10 10">
-                    <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" stroke-width="2" />
+                    <path d="M3 3l4 4M7 3L3 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
                 </svg>
             </button>
         </div>

--- a/src/renderer/loginWindow/loginnew.html
+++ b/src/renderer/loginWindow/loginnew.html
@@ -6,9 +6,16 @@
     <div id="titlebar">
         <div id="drag-region"></div>
         <div id="window-controls">
-            <button id="minimize" class="control-btn">_</button>
-            <button id="maximize" class="control-btn">□</button>
-            <button id="close" class="control-btn">x</button>
+            <button id="minimize" class="control-btn">
+                <svg class="control-icon" viewBox="0 0 10 10">
+                    <path d="M2 2h6v6" fill="none" stroke="currentColor" stroke-width="2" />
+                </svg>
+            </button>
+            <button id="close" class="control-btn">
+                <svg class="control-icon" viewBox="0 0 10 10">
+                    <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" stroke-width="2" />
+                </svg>
+            </button>
         </div>
     </div>
     <div class="login-container">

--- a/src/renderer/mainWindow/index.html
+++ b/src/renderer/mainWindow/index.html
@@ -11,9 +11,16 @@
         <div id="drag-region">数据库管理系统</div>
         <div id="window-controls">
             <button id="setting" class="control-btn" title="系统配置">⚙</button>
-            <button id="minimize" class="control-btn">_</button>
-            <button id="maximize" class="control-btn">□</button>
-            <button id="close" class="control-btn">x</button>
+            <button id="minimize" class="control-btn">
+                <svg class="control-icon" viewBox="0 0 10 10">
+                    <path d="M2 2h6v6" fill="none" stroke="currentColor" stroke-width="2" />
+                </svg>
+            </button>
+            <button id="close" class="control-btn">
+                <svg class="control-icon" viewBox="0 0 10 10">
+                    <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" stroke-width="2" />
+                </svg>
+            </button>
         </div>
     </div>
     <div class="main-container">

--- a/src/renderer/mainWindow/index.html
+++ b/src/renderer/mainWindow/index.html
@@ -13,12 +13,12 @@
             <button id="setting" class="control-btn" title="系统配置">⚙</button>
             <button id="minimize" class="control-btn">
                 <svg class="control-icon" viewBox="0 0 10 10">
-                    <path d="M2 2h6v6" fill="none" stroke="currentColor" stroke-width="2" />
+                    <path d="M2 3l3 3 3-3" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
                 </svg>
             </button>
             <button id="close" class="control-btn">
                 <svg class="control-icon" viewBox="0 0 10 10">
-                    <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" stroke-width="2" />
+                    <path d="M3 3l4 4M7 3L3 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
                 </svg>
             </button>
         </div>

--- a/src/renderer/mainWindow/mainWindow.html
+++ b/src/renderer/mainWindow/mainWindow.html
@@ -71,12 +71,12 @@
                 <div id="window-controls">
                     <button id="minimize" class="control-btn">
                         <svg class="control-icon" viewBox="0 0 10 10">
-                            <path d="M2 2h6v6" fill="none" stroke="currentColor" stroke-width="2" />
+                            <path d="M2 3l3 3 3-3" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
                         </svg>
                     </button>
                     <button id="close" class="control-btn">
                         <svg class="control-icon" viewBox="0 0 10 10">
-                            <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" stroke-width="2" />
+                            <path d="M3 3l4 4M7 3L3 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
                         </svg>
                     </button>
                 </div>

--- a/src/renderer/mainWindow/mainWindow.html
+++ b/src/renderer/mainWindow/mainWindow.html
@@ -69,9 +69,16 @@
             <span style="color: #000000;font-weight: 700;font-size: 22px; margin-left: 23px;">文档录入系统</span>
             <div class="top-right">
                 <div id="window-controls">
-                    <button id="minimize" class="control-btn">-</button>
-                    <button id="maximize" class="control-btn">□</button>
-                    <button id="close" class="control-btn">x</button>
+                    <button id="minimize" class="control-btn">
+                        <svg class="control-icon" viewBox="0 0 10 10">
+                            <path d="M2 2h6v6" fill="none" stroke="currentColor" stroke-width="2" />
+                        </svg>
+                    </button>
+                    <button id="close" class="control-btn">
+                        <svg class="control-icon" viewBox="0 0 10 10">
+                            <path d="M2 2l6 6M8 2L2 8" stroke="currentColor" stroke-width="2" />
+                        </svg>
+                    </button>
                 </div>
                 <div class="setting-box">
                     <img id="setting-icon" class="setting-icon" src="../assets/image/setting.png" alt="设置">

--- a/src/renderer/mainWindow/mainWindow.js
+++ b/src/renderer/mainWindow/mainWindow.js
@@ -43,7 +43,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // 获取控制按钮
   const minimizeBtn = getElement('minimize')
-  const maximizeBtn = getElement('maximize')
   const closeBtn = getElement('close')
 
   // 验证API可用性
@@ -56,24 +55,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     minimizeBtn.addEventListener('click', () => {
       console.log('[事件] 点击最小化按钮')
       window.electronAPI.minimize()
-    })
-  }
-  // 最大化/还原按钮
-  if (maximizeBtn) {
-    maximizeBtn.addEventListener('click', () => {
-      console.log('[事件] 点击最大化按钮')
-      window.electronAPI.maximize()
-    })
-
-    // 状态同步
-    window.electronAPI.onMaximized(() => {
-      maximizeBtn.textContent = '❐'
-      console.log('[状态] 窗口最大化')
-    })
-
-    window.electronAPI.onUnmaximized(() => {
-      maximizeBtn.textContent = '□'
-      console.log('[状态] 窗口还原')
     })
   }
   // 关闭按钮

--- a/src/renderer/mainWindow/renderer.js
+++ b/src/renderer/mainWindow/renderer.js
@@ -28,7 +28,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // 获取控制按钮
   const settingBtn = getElement('setting')
   const minimizeBtn = getElement('minimize')
-  const maximizeBtn = getElement('maximize')
   const closeBtn = getElement('close')
 
   // 验证API可用性
@@ -41,24 +40,6 @@ document.addEventListener('DOMContentLoaded', () => {
     minimizeBtn.addEventListener('click', () => {
       console.log('[事件] 点击最小化按钮')
       window.electronAPI.minimize()
-    })
-  }
-  // 最大化/还原按钮
-  if (maximizeBtn) {
-    maximizeBtn.addEventListener('click', () => {
-      console.log('[事件] 点击最大化按钮')
-      window.electronAPI.maximize()
-    })
-
-    // 状态同步
-    window.electronAPI.onMaximized(() => {
-      maximizeBtn.textContent = '❐'
-      console.log('[状态] 窗口最大化')
-    })
-
-    window.electronAPI.onUnmaximized(() => {
-      maximizeBtn.textContent = '□'
-      console.log('[状态] 窗口还原')
     })
   }
   // 关闭按钮


### PR DESCRIPTION
## Summary
- add a subtle border and shadow to better delineate app windows
- switch to KDE-inspired minimize and close SVG icons
- prevent resizing by disabling maximize capability

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint src/main/main.js src/preload.js src/renderer/loginWindow/login.js src/renderer/mainWindow/mainWindow.js src/renderer/mainWindow/renderer.js` (errors: e.g., `no-undef`, `no-unused-vars`)


------
https://chatgpt.com/codex/tasks/task_e_68c13ecf60dc832ca1fedc6f6efcb294