### PR TITLE
feat: separate numbering for normal and important docs

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -184,10 +184,12 @@ ipcMain.handle('database', async (_, { action, data }) => {
         const password = currentAccount.password
         aes256.init(password)
         const leadersEncrypt = data.review_leader.split(',').map(name => aes256.encrypt(name)).join(',')
+        const serial = dbInstance.statements.getNextTypeSerial.get({ doc_type: data.doc_type }).next
         const lastRowId = dbInstance.statements.createDocument.run(
           {
             uuid: uuid,
             doc_type: data.doc_type,
+            type_serial: serial,
             title: aes256.encrypt(data.title),
             sender_number: aes256.encrypt(data.sender_number),
             sender_date: aes256.encrypt(data.sender_date),
@@ -200,7 +202,8 @@ ipcMain.handle('database', async (_, { action, data }) => {
             drafting_unit: aes256.encrypt(data.drafting_unit),
             crgency_level: aes256.encrypt(data.crgency_level),
             review_leader: leadersEncrypt,
-            remarks: aes256.encrypt(data.remarks)
+            remarks: aes256.encrypt(data.remarks),
+            is_important: 0
           }).lastInsertRowid
         if (lastRowId && data.annotate.length > 0) {//如果有批注，创建完文件插入批注
           data.annotate.forEach(anno => {

--- a/src/renderer/components/resizelist/resizelist.js
+++ b/src/renderer/components/resizelist/resizelist.js
@@ -270,6 +270,9 @@ if (!customElements.get('resizable-table')) {
                 #table-body-table tr.selected {
                     background-color: #e6f7ff;
                 }
+                #table-body-table tr.important {
+                    background-color: #ffeaea;
+                }
 
                 #table-body-table td {
                     box-sizing: border-box;
@@ -557,6 +560,9 @@ if (!customElements.get('resizable-table')) {
                     }
                     row.appendChild(cell);
                 });
+                if (this.originalData[rowIndex].is_important) {
+                    row.classList.add('important');
+                }
                 // 单击仅高亮行
                 row.addEventListener('click', (e) => {
                     if (e.target.closest('.action-btn')) return;
@@ -607,7 +613,7 @@ if (!customElements.get('resizable-table')) {
             menuList.innerHTML = '';
 
             this.allKeys.forEach(key => {
-                if (key === 'uuid' || key === 'created_at' || key === 'docType' || key === 'doc_type' || key === 'review_leader') {
+                if (key === 'uuid' || key === 'created_at' || key === 'docType' || key === 'doc_type' || key === 'review_leader' || key === 'is_important') {
                     return
                 }
                 const isVisible = this.visibleKeys.includes(key);

--- a/src/renderer/mainWindow/mainWindow.js
+++ b/src/renderer/mainWindow/mainWindow.js
@@ -1102,7 +1102,8 @@ async function refreshDocList(type = 1, searchResult = null, _searchKey = null) 
     docs = docs.map(doc => ({
       ...doc,
       doc_type: doc.doc_type ?? doc.docType ?? doc.type ?? type,
-      docType: doc.docType ?? doc.doc_type ?? doc.type ?? type
+      docType: doc.docType ?? doc.doc_type ?? doc.type ?? type,
+      is_important: doc.is_important ?? doc.isImportant ?? 0
     }))
 
     // 获取文件状态，仅针对重要文件列表


### PR DESCRIPTION
## Summary
- keep separate serials for normal and important documents and track important flag
- duplicate documents when marking as important instead of moving them
- highlight normal entries that were promoted to important

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")

------
https://chatgpt.com/codex/tasks/task_e_68c14c5b1b88832cab488a552282556f